### PR TITLE
feat: Migrate AVX-512 and intrinsics to stable Rust

### DIFF
--- a/src/hpc.rs
+++ b/src/hpc.rs
@@ -97,7 +97,7 @@ pub fn encode_rle_simd(s: &[u8]) -> (String,Vec<u32>)
             // store both the positions and the HPC sequence
             //_mm256_mask_compressstoreu_epi8(res_ptr.offset(hpc_len) as *mut u8, _v_cmp_mask, v256);
             //_mm512_mask_compressstoreu_epi8(res_ptr.offset(hpc_len) as *mut u8, _v_cmp_mask, v);
-            //_mm_mask_compressstoreu_epi8(res_ptr.offset(hpc_len) as *mut u8, mask, v128);
+            //_mm_mask_compressstoreu_epi8(res_ptr.offset(hpc_len) as *mut i32, mask, v128);
             // would be nice to use these ^ but my machine doesnt support it
             let tmp_res_512 = _mm512_setzero_si512();
             let v128_512 = _mm512_cvtepi8_epi32(v128);
@@ -105,7 +105,7 @@ pub fn encode_rle_simd(s: &[u8]) -> (String,Vec<u32>)
             let tmp_res_128 = _mm512_cvtepi32_epi8(tmp_res_512);
             let mask128 = ((((1 as u32) << mask.count_ones()) as u32) - 1) as u16;
             _mm_mask_storeu_epi8            (res_ptr.offset(hpc_len as isize) as *mut i8, mask128, tmp_res_128);
-            _mm512_mask_compressstoreu_epi32(pos_ptr.offset(hpc_len as isize) as *mut u8, mask,    _positions);
+            _mm512_mask_compressstoreu_epi32(pos_ptr.offset(hpc_len as isize) as *mut i32, mask,    _positions);
         
              _positions = _mm512_add_epi32(_positions, _16);
             hpc_len += mask.count_ones() as usize;
@@ -130,7 +130,7 @@ pub fn encode_rle_simd(s: &[u8]) -> (String,Vec<u32>)
             let tmp_res_128 = _mm512_cvtepi32_epi8(tmp_res_512);
             let mask128 = ((((1 as u32) << mask.count_ones()) as u32) - 1) as u16;
             _mm_mask_storeu_epi8            (res_ptr.offset(hpc_len as isize) as *mut i8, mask128, tmp_res_128);
-            _mm512_mask_compressstoreu_epi32(pos_ptr.offset(hpc_len as isize) as *mut u8, mask,    _positions);
+            _mm512_mask_compressstoreu_epi32(pos_ptr.offset(hpc_len as isize) as *mut i32, mask,    _positions);
              _positions = _mm512_add_epi32(_positions, _16);
             hpc_len += mask.count_ones() as usize;
         }

--- a/src/hpc.rs
+++ b/src/hpc.rs
@@ -145,4 +145,3 @@ pub fn encode_rle_simd(s: &[u8]) -> (String,Vec<u32>)
     }
     //(String::new(),Vec::new())
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(core_intrinsics)]
-#![feature(stdarch_x86_avx512)]
+
 use nthash32::NtHashIterator;
 mod kminmer;
 pub use kminmer::{Kminmer, KminmerVec, KminmerHash};

--- a/src/nthash_avx512_32.rs
+++ b/src/nthash_avx512_32.rs
@@ -54,8 +54,8 @@ impl<'a> NtHashSIMDIterator<'a> {
 
         let mask = _mm512_cmp_epu32_mask(_hVal, _hashBound, 1 /*LT*/);
         let nb_ones = mask.count_ones() as usize;
-        _mm512_mask_compressstoreu_epi32(hashes_ptr as *mut u8, mask, _hVal);
-        _mm512_mask_compressstoreu_epi32(pos_ptr as *mut u8, mask, _positions);
+        _mm512_mask_compressstoreu_epi32(hashes_ptr as *mut i32, mask, _hVal);
+        _mm512_mask_compressstoreu_epi32(pos_ptr as *mut i32, mask, _positions);
         _positions = _mm512_add_epi32(_positions, _16);
 
         NtHashSIMDIterator {
@@ -136,8 +136,8 @@ impl<'a> Iterator for NtHashSIMDIterator<'a> {
                         mask &= (((1 as u32) << (sentinel % 16) as u32) - 1) as u16; // ignore the rest of the buffer, the string end earlier
                         nb_ones = mask.count_ones();
                     }
-                    _mm512_mask_compressstoreu_epi32(self.hashes_ptr  as *mut u8, mask, _hVal);
-                    _mm512_mask_compressstoreu_epi32(self.pos_ptr  as *mut u8, mask, _positions);                
+                    _mm512_mask_compressstoreu_epi32(self.hashes_ptr  as *mut i32, mask, _hVal);
+                    _mm512_mask_compressstoreu_epi32(self.pos_ptr  as *mut i32, mask, _positions);                
                 }
                 _positions = _mm512_add_epi32(_positions, _16);
                 if nb_ones > 0

--- a/src/nthash_avx512_32.rs
+++ b/src/nthash_avx512_32.rs
@@ -523,4 +523,3 @@ unsafe fn _mm512_NTC_epu32_sliding(kmerSeq: &[u8], offsetOut: usize, offsetIn: u
 
     (_hVal, _fhVal, _rhVal)
 }
-

--- a/src/nthash_hpc.rs
+++ b/src/nthash_hpc.rs
@@ -204,8 +204,9 @@ impl<'a> Iterator for NtHashHPCIterator<'a> {
             let mut h_seqk :H;
             let mut rc_seqk :H;
 
+// Replaced unstable intrinsics
             // special case for very first element
-            if std::intrinsics::unlikely(self.first_element)
+            if self.first_element
             {
                 self.first_element = false;
                 loop
@@ -223,24 +224,24 @@ impl<'a> Iterator for NtHashHPCIterator<'a> {
 
                 // prepare everything for the next char
                 (h_seqk, rc_seqk) = (h(cur),rc(cur));
-                let pos = std::intrinsics::unchecked_rem(self.buffer_pos+k,BUFLEN);
+                let pos = (self.buffer_pos+k) % BUFLEN;
                 *self.h_rc_buffer.get_unchecked_mut(pos) = (h_seqk, rc_seqk);
                 *self.idx_buffer. get_unchecked_mut(pos) = self.current_idx_plus_k;
                 self.buffer_pos += 1;
 
                 hash = H::min(self.rh, self.fh);
                 if hash <= self.hash_bound {
-                    prev_current_idx = *self.idx_buffer.get_unchecked(std::intrinsics::unchecked_rem(self.buffer_pos+BUFLEN-1,BUFLEN));
+                    prev_current_idx = *self.idx_buffer.get_unchecked((self.buffer_pos+BUFLEN-1) % BUFLEN);
                     return Some((prev_current_idx, (self.current_idx_plus_k-1) as usize, hash))
                 }
             }
             else  {
-                (h_seqk, rc_seqk)  = *self.h_rc_buffer .get_unchecked(std::intrinsics::unchecked_rem(self.buffer_pos+k-1,BUFLEN));
+                (h_seqk, rc_seqk)  = *self.h_rc_buffer .get_unchecked((self.buffer_pos+k-1) % BUFLEN);
             }
 
             loop
             {
-                let (h_seqi, rc_seqi)  = self.h_rc_buffer .get_unchecked(std::intrinsics::unchecked_rem(self.buffer_pos-1,BUFLEN));
+                let (h_seqi, rc_seqi)  = self.h_rc_buffer .get_unchecked((self.buffer_pos-1) % BUFLEN);
 
                 self.fh = self.fh.rotate_left(1) ^ h_seqi.rotate_left(k as u32) ^ h_seqk;
 
@@ -253,7 +254,7 @@ impl<'a> Iterator for NtHashHPCIterator<'a> {
                 loop
                 {
                     self.current_idx_plus_k += 1;
-                    if  std::intrinsics::unlikely(self.current_idx_plus_k >= self.seq_len) {
+                    if  self.current_idx_plus_k >= self.seq_len {
                         break;
                     }
                     cur = *self.seq.get_unchecked(self.current_idx_plus_k);
@@ -268,7 +269,7 @@ impl<'a> Iterator for NtHashHPCIterator<'a> {
 
                 // prepare everything for the next char
                 (h_seqk, rc_seqk) = (h(cur),rc(cur));
-                let pos = std::intrinsics::unchecked_rem(self.buffer_pos+k,BUFLEN);
+                let pos = (self.buffer_pos+k) % BUFLEN;
                 *self.h_rc_buffer.get_unchecked_mut(pos) = (h_seqk, rc_seqk);
                 *self.idx_buffer. get_unchecked_mut(pos) = self.current_idx_plus_k;
                 self.buffer_pos += 1;
@@ -277,7 +278,7 @@ impl<'a> Iterator for NtHashHPCIterator<'a> {
                 if hash <= self.hash_bound { break; }
             }
 
-        prev_current_idx = *self.idx_buffer.get_unchecked(std::intrinsics::unchecked_rem(self.buffer_pos+BUFLEN-1,BUFLEN));
+        prev_current_idx = *self.idx_buffer.get_unchecked((self.buffer_pos+BUFLEN-1) % BUFLEN);
         Some((prev_current_idx, (self.current_idx_plus_k-1) as usize, hash))
         }
     }


### PR DESCRIPTION
This PR updates `rust-seq2kminmers` to use **stable Rust features**, removing the need for nightly Rust or unstable features for AVX-512 support.

### Key Changes:
- **Removed unstable feature flags** (`#![feature(core_intrinsics)]`, `#![feature(stdarch_x86_avx512)]`).
- **Replaced unstable intrinsics** (e.g., `std::intrinsics::unlikely`, `std::intrinsics::unchecked_rem`) with stable equivalents.
- **Fixed AVX-512 type mismatches** and updated the implementation to work on stable Rust.

### Why?
Enables me to build https://github.com/ekimb/mapquik
